### PR TITLE
Update everything to work with modern gleam

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,8 +7,8 @@ repository = { type = "github", user = "lunarmagpie", repo = "gts" }
 links = [{ title = "Website", href = "https://github.com/lunarmagpie/gts" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.28"
-gleam_erlang = "~> 0.18"
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_erlang = "~> 1.1.0"
 
 [dev-dependencies]
-gleeunit = "~> 0.10"
+gleeunit = "~> 1.6.1"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.18.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C69F59D086AD50B80DE294FB0963550630971C9DC04E92B1F7AEEDD2C0BE226C" },
-  { name = "gleam_stdlib", version = "0.28.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "73F0A89FADE5022CBEF6D6C3551F9ADCE7054AFCE0CB1DC4C6D5AB4CA62D0111" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gleam_erlang", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "D7A2E71CE7F6B513E62F9A9EF6DFDE640D9607598C477FCCADEF751C45FD82E7" },
+  { name = "gleam_stdlib", version = "0.63.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "962B25C667DA07F4CAB32001F44D3C41C1A89E58E3BBA54F183B482CF6122150" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
 ]
 
 [requirements]
-gleam_erlang = "~> 0.18"
-gleam_stdlib = "~> 0.28"
-gleeunit = "~> 0.10"
+gleam_erlang = { version = "~> 1.1.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleeunit = { version = "~> 1.6.1" }

--- a/src/ets/config/privacy.gleam
+++ b/src/ets/config/privacy.gleam
@@ -1,0 +1,5 @@
+pub type Privacy {
+  Private
+  Protected
+  Public
+}

--- a/src/ets/config/write_concurrency.gleam
+++ b/src/ets/config/write_concurrency.gleam
@@ -1,0 +1,5 @@
+pub type WriteConcurrency {
+  True
+  False
+  Auto
+}

--- a/src/ets/internal/ets_bindings.gleam
+++ b/src/ets/internal/ets_bindings.gleam
@@ -1,26 +1,41 @@
 import gleam/erlang/atom
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/erlang/process
 
-pub external fn all() -> Nil =
-  "ets" "all"
 
-pub external fn drop(table: atom.Atom) -> Nil =
-  "ets" "delete"
 
-pub external fn delete_key(table: atom.Atom, key: k) -> Nil =
-  "ets" "delete"
+@external(erlang, "ets", "new")
+pub fn new(name: atom.Atom, props: List(dynamic.Dynamic)) -> Nil
 
-pub external fn delete_all_objects(table: atom.Atom) -> Nil =
-  "ets" "delete_all_objects"
+@external(erlang, "ets", "all")
+pub fn all() -> Nil
 
-/// TODO: Check if should be v or #(k,v)
-pub external fn delete_object(table: atom.Atom, object: v) -> Nil =
-  "ets" "delete_object"
+@external(erlang, "ets", "delete")
+pub fn drop(table: atom.Atom) -> Nil
 
-pub external fn insert(table: atom.Atom, tuple: #(k, v)) -> Nil =
-  "ets" "insert"
+@external(erlang, "ets", "delete")
+pub fn delete_key(table: atom.Atom, key: k) -> Nil
 
-pub external fn lookup(table: atom.Atom, key: k) -> List(#(k, v)) =
-  "ets" "lookup"
+@external(erlang, "ets", "delete_all_objects")
+pub fn delete_all_objects(table: atom.Atom) -> Nil
 
-pub external fn give_away(table: atom.Atom, pid: pid, gift_data: any) -> Nil =
-  "ets" "give_away"
+/// TODO: Check if this should be v or #(k, v)
+@external(erlang, "ets", "delete_object")
+pub fn delete_object(table: atom.Atom, object: v) -> Nil
+
+@external(erlang, "ets", "insert")
+pub fn insert(table: atom.Atom, tuple: #(k, v)) -> Nil
+
+@external(erlang, "ets", "lookup")
+pub fn lookup(table: atom.Atom, key: k) -> List(#(k, v))
+
+@external(erlang, "ets", "give_away")
+pub fn give_away(table: atom.Atom, pid: process.Pid, gift_data: any) -> Nil
+
+
+@external(erlang, "gleam_stdlib", "identity")
+pub fn cast(a: anything) -> dynamic.Dynamic
+
+@external(erlang, "gleam_stdlib", "identity")
+pub fn anytype(data: decode.Dynamic) -> anytype

--- a/src/ets/table.gleam
+++ b/src/ets/table.gleam
@@ -3,6 +3,7 @@
 import gleam/erlang/atom
 import gleam/erlang/process
 import ets/internal/ets_bindings
+import gleam/dynamic.{type Dynamic}
 
 pub opaque type Table(k, v) {
   Table(name: atom.Atom)
@@ -22,6 +23,6 @@ pub fn drop(table: Table(k, v)) {
 }
 
 /// Give the table to another process.
-pub fn give_away(table: Table(k, v), pid: process.Pid, gift_data: any) -> Nil {
+pub fn give_away(table: Table(k, v), pid: process.Pid, gift_data: Dynamic) -> Nil {
   ets_bindings.give_away(table.name, pid, gift_data)
 }

--- a/src/ets/table/ordered_set.gleam
+++ b/src/ets/table/ordered_set.gleam
@@ -32,7 +32,7 @@ pub fn lookup(set: OrderedSet(k, v), key: k) -> Result(List(#(k, v)), Nil) {
     )
   {
     [] -> Error(Nil)
-    else -> Ok(else)
+    kvs -> Ok(kvs)
   }
 }
 

--- a/src/ets/table/set.gleam
+++ b/src/ets/table/set.gleam
@@ -31,7 +31,7 @@ pub fn lookup(set: Set(k, v), key: k) -> Result(v, Nil) {
     )
   {
     [] -> Error(Nil)
-    [value, ..] -> Ok(value.1)
+    [#(_, value), ..] -> Ok(value)
   }
 }
 

--- a/src/gts.gleam
+++ b/src/gts.gleam
@@ -3,23 +3,22 @@ import ets/builder
 import ets/config/write_concurrency
 import ets/table/set
 
+
 pub fn main() {
-  let set: set.Set(String, String) =
+  let myset: set.Set(String, String) =
     builder.new("example_table")
     |> builder.write_concurrency(write_concurrency.True)
     |> builder.set()
 
-  set
-  |> set.insert("hello", "world")
-  set
-  |> set.insert("hello2", "world2")
+  set.insert(myset, "hello", "world")
+  set.insert(myset, "hello2", "world2")
 
-  set
-  |> set.delete("hello")
+  set.delete(myset, "hello")
 
-  set
-  |> set.lookup("hello2")
-  |> io.debug()
+  case set.lookup(myset, "hello2") {
+    Ok(val) -> io.println("yooo " <> val)
+    Error(_) -> Nil
+  }
 
-  io.debug(set)
+  // io.debug(set)
 }

--- a/test/gts_test.gleam
+++ b/test/gts_test.gleam
@@ -9,7 +9,7 @@ pub fn main() {
 }
 
 // gleeunit test functions end in `_test`
-pub fn test_set_insert() {
+pub fn set_insert_test() {
   builder.new("test_name")
   |> builder.set()
   |> set.insert("hello", "world")
@@ -17,11 +17,21 @@ pub fn test_set_insert() {
   |> should.equal(Ok("world"))
 }
 
-pub fn test_ordered_set() {
-  builder.new("test_name")
+pub fn set_insert_difftype_test() {
+  builder.new("test_name_whatever")
+  |> builder.set()
+  |> set.insert("hello", 2)
+  |> set.lookup("hello")
+  |> should.equal(Ok(2))
+}
+
+pub fn ordered_set_test() {
+  let myset = builder.new("test_name2")
   |> builder.ordered_set()
-  |> ordered_set.insert(1, 2)
-  |> ordered_set.insert(2, 3)
-  |> ordered_set.lookup(1)
+
+  ordered_set.insert(myset, 1, 2)
+  ordered_set.insert(myset, 2, 3)
+
+  ordered_set.lookup(myset, 1)
   |> should.equal(Ok([#(1, 2)]))
 }


### PR DESCRIPTION
fixes #4

this is revision one, where things don't change as much as possible.

to be clear, this is very jank. I made an issue at https://github.com/gleam-lang/gleam/issues/4987



some less jank ways forward:

### take advantage of `Dynamic` machinery much more heavily.

creating a `Codec`/`Serde` type and then adding concrete implementations of it to tables would allow for typechecked insertions & retrievals from the ets:

```
pub type Codec(t) {
  Codec(
    encode: fn(t) -> dynamic.Dynamic,
    decode: decode.Decoder(t),
  )
}

pub opaque type MyTable(k, v) {
  MyTable(
    name: String,
    key_codec: Codec(k),
    value_codec: Codec(v),
  )
}
```

could create an assortment of known codecs for the functions found within https://hexdocs.pm/gleam_stdlib/gleam/dynamic.html / https://hexdocs.pm/gleam_stdlib/gleam/dynamic/decode.html

and then could create a fallback decoder for unknown types 

```
pub fn wasd() -> decode.Decoder(anytype) {
  decode.new_primitive_decoder("anytype", fn(data) {
    Ok(dynamic_anytype(data))
  })
}

@external(erlang, "gleam_stdlib", "identity")
fn dynamic_anytype(data: decode.Dynamic) -> anytype
```


I think we still have to use the jank `cast()` for now, though.

*but*, any other type that isn't just a fallback cast does get typechecked. could do typechecked records and shit too, although I don't see a way to go from a record to a dynamic..


### type/wrap `ets_bindings` better.

this can make use of some dynamic machinery to figure out the type of things, but a lot of the ets bindings have sum accept/return types. 
- `new` returns a `tid` or an `atom` depending on if `named_table` is passed
- *everything else* accepts either a tid or an `atom`
- `insert` supports a kv tuple or a list of tuples

typing these / asserting/checking them with dynamic machinery would be good.


### better defining return vals

`Result(anything, Nil)` is kinda worthless. and a lookup that returns nothing is absolutely different from a lookup that causes an error, or has an incorrect type. take advantage of `Option(whatever)`

### more tests!

testing for failures would be really good. the old tests failed because they were creating two tables by the same names

### don't distinguish between table types?

right now there is absolutely no interface difference between these.